### PR TITLE
Topbar - move react to peerDependencies 

### DIFF
--- a/packages/topbar/package.json
+++ b/packages/topbar/package.json
@@ -18,13 +18,16 @@
   "author": "Michael Chan <mijoch@gmail.com>",
   "private": false,
   "dependencies": {
-    "react": "^15.6.1",
     "superagent": "^3.8.0"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1"
   },
   "devDependencies": {
     "@types/react": "^16.0.5",
     "html-webpack-plugin": "^3.0.6",
     "markdown-toc": "^1.2.0",
+    "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "rollup": "^0.56.5",
     "rollup-plugin-typescript2": "^0.12.0",

--- a/packages/topbar/package.json
+++ b/packages/topbar/package.json
@@ -21,7 +21,7 @@
     "superagent": "^3.8.0"
   },
   "peerDependencies": {
-    "react": "^15.6.1"
+    "react": ">= 15.6.1 < 17"
   },
   "devDependencies": {
     "@types/react": "^16.0.5",

--- a/packages/topbar/rollup.config.js
+++ b/packages/topbar/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from "rollup-plugin-typescript2";
 import tsc from "typescript";
 import pkg from "./package.json";
 
-const external = Object.keys(pkg.dependencies || {});
+const external = Object.keys(Object.assign({}, pkg.dependencies, pkg.peerDependencies));
 
 export default [
   {


### PR DESCRIPTION
In the process of moving our app to React 16, I noticed that topbar was including it's own (incompatible) version of React in the bundle. Declaring it as a peer dependency allows topbar to rely on the consuming app's `react` module  and avoids having multiple versions in the bundle. It seems like this would be desirable, but if there's a better way to handle this I'd love to know.

I'm not _quite_ sure how this works with the lerna monorepo regarding lockfiles and such... let me know if there's something I should do.